### PR TITLE
Feed group tabs initial implementation for sponsorblock 24.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,16 @@
+Modified variant of Newpipe with a rough implementation of Feed Group Tabs
+
+https://github.com/TeamNewPipe/NewPipe/issues/3319
+
+![03](.github/images/feed_group_tabs.gif)
+
+I've only tried this against Youtube. YMMV
+
+Build on the `feed_groups-tab` branch
+
+Original Readme below
+-------
+
 # NewPipe x SponsorBlock x Return YouTube Dislike
 A fork of [NewPipe](https://github.com/TeamNewPipe/NewPipe) with [SponsorBlock](https://sponsor.ajay.app/) and [Return YouTube Dislike](https://returnyoutubedislike.com/) functionality.
 

--- a/app/src/main/java/org/schabi/newpipe/local/feed/FeedFragment.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/feed/FeedFragment.kt
@@ -211,8 +211,7 @@ class FeedFragment : BaseStateFragment<FeedState>() {
         super.onCreateOptionsMenu(menu, inflater)
 
         activity.supportActionBar?.setDisplayShowTitleEnabled(true)
-        activity.supportActionBar?.setTitle(R.string.fragment_feed_title)
-        activity.supportActionBar?.subtitle = groupName
+        activity.supportActionBar?.setTitle(groupName)
 
         inflater.inflate(R.menu.menu_feed_fragment, menu)
         updateTogglePlayedItemsButton(menu.findItem(R.id.menu_item_feed_toggle_played_items))

--- a/app/src/main/java/org/schabi/newpipe/settings/SelectFeedGroupFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/SelectFeedGroupFragment.java
@@ -1,0 +1,187 @@
+package org.schabi.newpipe.settings;
+
+import android.content.DialogInterface;
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ImageView;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.content.res.AppCompatResources;
+import androidx.fragment.app.DialogFragment;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+
+import org.schabi.newpipe.R;
+import org.schabi.newpipe.database.feed.model.FeedGroupEntity;
+import org.schabi.newpipe.error.ErrorUtil;
+import org.schabi.newpipe.local.feed.FeedDatabaseManager;
+import org.schabi.newpipe.local.subscription.FeedGroupIcon;
+import org.schabi.newpipe.util.ThemeHelper;
+
+import java.util.List;
+import java.util.Vector;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers;
+import io.reactivex.rxjava3.core.Observer;
+import io.reactivex.rxjava3.disposables.Disposable;
+import io.reactivex.rxjava3.schedulers.Schedulers;
+
+public class SelectFeedGroupFragment extends DialogFragment {
+
+    private OnSelectedListener onSelectedListener = null;
+    private OnCancelListener onCancelListener = null;
+
+    private List<FeedGroupEntity> feedGroups = new Vector<>();
+    private FeedGroupEntity allSubscriptionsFeedGroup;
+
+    public void setOnSelectedListener(final OnSelectedListener listener) {
+        onSelectedListener = listener;
+    }
+
+    public void setOnCancelListener(final OnCancelListener listener) {
+        onCancelListener = listener;
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+    // Init
+    //////////////////////////////////////////////////////////////////////////*/
+
+    @Override
+    public void onCreate(@Nullable final Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setStyle(STYLE_NO_TITLE, ThemeHelper.getMinWidthDialogTheme(requireContext()));
+        allSubscriptionsFeedGroup =
+                new FeedGroupEntity(FeedGroupEntity.GROUP_ALL_ID,
+                        requireContext().getString(R.string.all),
+                        FeedGroupIcon.RSS,
+                        -1);
+    }
+
+    @Override
+    public View onCreateView(@NonNull final LayoutInflater inflater, final ViewGroup container,
+                             final Bundle savedInstanceState) {
+        final View v = inflater.inflate(
+                R.layout.select_feed_group_fragment, container, false);
+        final RecyclerView recyclerView = v.findViewById(R.id.items_list);
+        recyclerView.setLayoutManager(new LinearLayoutManager(getContext()));
+        final SelectFeedGroupAdapter feedGroupAdapter = new SelectFeedGroupAdapter();
+        recyclerView.setAdapter(feedGroupAdapter);
+
+        final FeedDatabaseManager feedDatabaseManager = new FeedDatabaseManager(requireContext());
+        feedDatabaseManager.groups().toObservable()
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe(getFeedGroupsObserver());
+        return v;
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+    // Handle actions
+    //////////////////////////////////////////////////////////////////////////*/
+
+    @Override
+    public void onCancel(@NonNull final DialogInterface dialogInterface) {
+        super.onCancel(dialogInterface);
+        if (onCancelListener != null) {
+            onCancelListener.onCancel();
+        }
+    }
+
+    private void clickedItem(final int position) {
+        if (onSelectedListener != null) {
+            final FeedGroupEntity entry = feedGroups.get(position);
+            onSelectedListener
+                    .onFeedGroupSelected(entry.getUid(), entry.getName(), entry.getIcon());
+        }
+        dismiss();
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+    // Item handling
+    //////////////////////////////////////////////////////////////////////////*/
+
+    private void displayFeedGroups(final List<FeedGroupEntity> newFeedGroups) {
+        this.feedGroups = Stream.concat(Stream.of(allSubscriptionsFeedGroup),
+                        newFeedGroups.stream()).collect(Collectors.toList());
+    }
+
+    private Observer<List<FeedGroupEntity>> getFeedGroupsObserver() {
+        return new Observer<List<FeedGroupEntity>>() {
+            @Override
+            public void onSubscribe(@NonNull final Disposable disposable) { }
+
+            @Override
+            public void onNext(@NonNull final List<FeedGroupEntity> newFeedGroups) {
+                displayFeedGroups(newFeedGroups);
+            }
+
+            @Override
+            public void onError(@NonNull final Throwable exception) {
+                ErrorUtil.showUiErrorSnackbar(SelectFeedGroupFragment.this,
+                        "Loading feed groups", exception);
+            }
+
+            @Override
+            public void onComplete() { }
+        };
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+    // Interfaces
+    //////////////////////////////////////////////////////////////////////////*/
+
+    public interface OnSelectedListener {
+        void onFeedGroupSelected(long feedGroupId,
+                                 String feedGroupName,
+                                 FeedGroupIcon feedGroupIcon);
+    }
+
+    public interface OnCancelListener {
+        void onCancel();
+    }
+
+    private class SelectFeedGroupAdapter
+            extends RecyclerView.Adapter<SelectFeedGroupAdapter.SelectFeedGroupItemHolder> {
+        @NonNull
+        @Override
+        public SelectFeedGroupItemHolder onCreateViewHolder(final ViewGroup parent,
+                                                            final int viewType) {
+            final View item = LayoutInflater.from(parent.getContext())
+                    .inflate(R.layout.select_feed_group_item, parent, false);
+            return new SelectFeedGroupItemHolder(item);
+        }
+
+        @Override
+        public void onBindViewHolder(final SelectFeedGroupItemHolder holder, final int position) {
+            final FeedGroupEntity entry = feedGroups.get(position);
+            holder.titleView.setText(entry.getName());
+            holder.thumbnailView
+                    .setImageDrawable(AppCompatResources.getDrawable(requireContext(),
+                            entry.getIcon().getDrawableResource()));
+            holder.view.setOnClickListener(view -> clickedItem(position));
+        }
+
+        @Override
+        public int getItemCount() {
+            return feedGroups.size();
+        }
+
+        public class SelectFeedGroupItemHolder extends RecyclerView.ViewHolder {
+            public final View view;
+            final ImageView thumbnailView;
+            final TextView titleView;
+            SelectFeedGroupItemHolder(final View v) {
+                super(v);
+                this.view = v;
+                thumbnailView = v.findViewById(R.id.itemThumbnailView);
+                titleView = v.findViewById(R.id.itemTitleView);
+            }
+        }
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/settings/tabs/ChooseTabsFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/tabs/ChooseTabsFragment.java
@@ -32,6 +32,7 @@ import org.schabi.newpipe.error.ErrorInfo;
 import org.schabi.newpipe.error.ErrorUtil;
 import org.schabi.newpipe.error.UserAction;
 import org.schabi.newpipe.settings.SelectChannelFragment;
+import org.schabi.newpipe.settings.SelectFeedGroupFragment;
 import org.schabi.newpipe.settings.SelectKioskFragment;
 import org.schabi.newpipe.settings.SelectPlaylistFragment;
 import org.schabi.newpipe.settings.tabs.AddTabDialog.ChooseTabListItem;
@@ -174,6 +175,14 @@ public class ChooseTabsFragment extends Fragment {
         }
 
         switch (type) {
+            case FEED:
+                final SelectFeedGroupFragment selectFeedGroupFragment =
+                        new SelectFeedGroupFragment();
+                selectFeedGroupFragment.setOnSelectedListener(
+                        (feedGroupId, feedGroupName, feedGroupIcon) ->
+                                addTab(new Tab.FeedTab(feedGroupId, feedGroupName, feedGroupIcon)));
+                selectFeedGroupFragment.show(getParentFragmentManager(), "select_feed_group");
+                return;
             case KIOSK:
                 final SelectKioskFragment selectKioskFragment = new SelectKioskFragment();
                 selectKioskFragment.setOnSelectedListener((serviceId, kioskId, kioskName) ->
@@ -226,6 +235,9 @@ public class ChooseTabsFragment extends Fragment {
                     returnList.add(new ChooseTabListItem(tab.getTabId(),
                             getString(R.string.kiosk_page_summary),
                             R.drawable.ic_whatshot));
+                    break;
+                case FEED:
+                    returnList.add(new ChooseTabListItem(context, tab));
                     break;
                 case CHANNEL:
                     returnList.add(new ChooseTabListItem(tab.getTabId(),

--- a/app/src/main/res/layout/select_feed_group_fragment.xml
+++ b/app/src/main/res/layout/select_feed_group_fragment.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="13dp">
+
+    <org.schabi.newpipe.views.NewPipeTextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="10dp"
+        android:layout_marginLeft="10dp"
+        android:layout_marginTop="5dp"
+        android:layout_marginEnd="5dp"
+        android:layout_marginRight="5dp"
+        android:layout_marginBottom="10dp"
+        android:text="@string/select_a_feed_group"
+        android:textAppearance="?android:attr/textAppearanceLarge" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/items_list"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        tools:listitem="@layout/select_feed_group_item" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/select_feed_group_item.xml
+++ b/app/src/main/res/layout/select_feed_group_item.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="?attr/selectableItemBackground"
+    android:clickable="true"
+    android:focusable="true"
+    android:orientation="vertical"
+    android:padding="5dp">
+
+    <com.google.android.material.imageview.ShapeableImageView
+        android:id="@+id/itemThumbnailView"
+        android:layout_width="42dp"
+        android:layout_height="42dp"
+        android:layout_alignParentStart="true"
+        android:layout_alignParentLeft="true"
+        android:layout_alignParentTop="true"
+        android:layout_marginStart="3dp"
+        android:layout_marginRight="8dp"
+        android:src="@drawable/placeholder_person"
+        app:shapeAppearance="@style/CircularImageView"
+        tools:ignore="RtlHardcoded" />
+
+    <org.schabi.newpipe.views.NewPipeTextView
+        android:id="@+id/itemTitleView"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_centerVertical="true"
+        android:layout_marginBottom="@dimen/video_item_search_image_right_margin"
+        android:layout_toEndOf="@+id/itemThumbnailView"
+        android:layout_toRightOf="@+id/itemThumbnailView"
+        android:ellipsize="end"
+        android:lines="1"
+        android:textAppearance="?android:attr/textAppearanceListItem"
+        tools:text="Feed Group Name, Lorem ipsum" />
+
+</RelativeLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -408,6 +408,7 @@
     <string name="kiosk_page_summary">Kiosk Page</string>
     <string name="default_kiosk_page_summary">Default Kiosk</string>
     <string name="channel_page_summary">Channel Page</string>
+    <string name="select_a_feed_group">Select a feed group</string>
     <string name="select_a_channel">Select a channel</string>
     <string name="no_channel_subscribed_yet">No channel subscriptions yet</string>
     <string name="select_a_playlist">Select a playlist</string>


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [ ] Bugfix (user facing)
- [x] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)


#### APK testing 
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
