### PR TITLE
Add gradle parameter to skip formatKtLint and use in CI

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -128,7 +128,10 @@ task formatKtlint(type: JavaExec) {
 }
 
 afterEvaluate {
-    preDebugBuild.dependsOn formatKtlint, runKtlint
+    if (!System.properties.containsKey('skipFormatKtlint')) {
+        preDebugBuild.dependsOn formatKtlint
+    }
+    preDebugBuild.dependsOn runKtlint
 }
 
 dependencies {


### PR DESCRIPTION
Author: XiangRongLin

<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
Add gradle parameter to skip formatKtLint and use in CI

#### Fixes the following issue(s)
This way runKtlint is not executed twice during CI

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
